### PR TITLE
Fix validate theta method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding='UTF-8') as fh:
 
 setuptools.setup(
     name="spyrograph",
-    version="0.11.3",
+    version="0.12.0",
     author="Chris Greening",
     author_email="chris@christophergreening.com",
     description="Library for drawing spirographs in Python",

--- a/spyrograph/_roulette.py
+++ b/spyrograph/_roulette.py
@@ -167,7 +167,7 @@ class _Roulette(ABC):
         ) -> "":
         # pylint: disable=line-too-long
         theta_values = (theta_start, theta_stop, theta_step)
-        multiple_thetas = thetas and any(theta_values)
+        multiple_thetas = thetas is not None and any(theta_values)
         if multiple_thetas:
             raise ValueError("Multiple definitions of theta were passed in as argument which is ambiguous - please define only one set of theta values.")
         if not thetas:

--- a/spyrograph/_roulette.py
+++ b/spyrograph/_roulette.py
@@ -170,7 +170,7 @@ class _Roulette(ABC):
         multiple_thetas = thetas is not None and any(theta_values)
         if multiple_thetas:
             raise ValueError("Multiple definitions of theta were passed in as argument which is ambiguous - please define only one set of theta values.")
-        if not thetas:
+        if thetas is None:
             thetas = []
             theta = theta_start
             if theta_step is None:


### PR DESCRIPTION
## Description
The validate theta method was broken when passing a `numpy` array. `Numpy` flags a `ValueError` when doing bool checks due to ambiguity. We should've been using an `is None` check anyway as that is more idiomatic and makes more sense given the default value for the arg

## Checklist

* [x] I followed the guidelines in our Contributing document
* [x] I added an explanation of my changes