### PR TITLE
Add scale feature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding='UTF-8') as fh:
 
 setuptools.setup(
     name="spyrograph",
-    version="0.17.5",
+    version="0.18.0",
     author="Chris Greening",
     author_email="chris@christophergreening.com",
     description="Library for drawing spirographs in Python",

--- a/spyrograph/_trochoid.py
+++ b/spyrograph/_trochoid.py
@@ -87,7 +87,7 @@ class _Trochoid(ABC):
             scaled_shape = self.__class__(
                 R=self.R*factor,
                 r=self.r*factor,
-                thetas=thetas
+                thetas=self.thetas
             )
         return scaled_shape
 

--- a/spyrograph/_trochoid.py
+++ b/spyrograph/_trochoid.py
@@ -74,6 +74,9 @@ class _Trochoid(ABC):
         self.y += self.origin[1]
         self.coords = list(zip(self.x, self.y, self.thetas))
 
+    def scale(self):
+        pass
+
     def plot(self, **kwargs) -> Tuple["matplotlib.matplotlib.Figure", "matplotlib.axes._axes.Axes"]:
         """Return matplotlib figure and axis objects after plotting the figure
 

--- a/spyrograph/_trochoid.py
+++ b/spyrograph/_trochoid.py
@@ -74,8 +74,22 @@ class _Trochoid(ABC):
         self.y += self.origin[1]
         self.coords = list(zip(self.x, self.y, self.thetas))
 
-    def scale(self):
-        pass
+    def scale(self, factor: Number) -> Union["_Trochoid", "_Cycloid"]:
+        """Return shape but with input parameters scaled by a given input factor"""
+        try:
+            scaled_shape = self.__class__(
+                R=self.R*factor,
+                r=self.r*factor,
+                d=self.d*factor,
+                thetas=self.thetas
+            )
+        except TypeError:
+            scaled_shape = self.__class__(
+                R=self.R*factor,
+                r=self.r*factor,
+                thetas=thetas
+            )
+        return scaled_shape
 
     def plot(self, **kwargs) -> Tuple["matplotlib.matplotlib.Figure", "matplotlib.axes._axes.Axes"]:
         """Return matplotlib figure and axis objects after plotting the figure

--- a/spyrograph/_trochoid.py
+++ b/spyrograph/_trochoid.py
@@ -75,7 +75,33 @@ class _Trochoid(ABC):
         self.coords = list(zip(self.x, self.y, self.thetas))
 
     def scale(self, factor: Number) -> Union["_Trochoid", "_Cycloid"]:
-        """Return shape but with input parameters scaled by a given input factor"""
+        """Return shape with input parameters scaled by a given input factor.
+
+        This method creates a new shape by scaling the input parameters R, r,
+        and d (when applicable) by the given factor. The new shape is an
+        instance of the same class as the original shape.
+
+        Parameters
+        ----------
+        factor : Number
+            The factor by which to scale the input parameters (R, r, and d).
+
+        Returns
+        -------
+        Union["_Trochoid", "_Cycloid"]
+            A new shape instance with the scaled input parameters.
+
+        Examples
+        --------
+        >>> hypotrochoid = Hypotrochoid(10, 5, 3, thetas=[0, 1, 2])
+        >>> scaled_hypotrochoid = hypotrochoid.scale(2)
+        >>> scaled_hypotrochoid.R
+        20
+        >>> scaled_hypotrochoid.r
+        10
+        >>> scaled_hypotrochoid.d
+        6
+        """
         try:
             scaled_shape = self.__class__(
                 R=self.R*factor,

--- a/tests/_roulette.py
+++ b/tests/_roulette.py
@@ -21,6 +21,26 @@ class _TestGeneral:
             thetas=thetas
         )
 
+    def test_scale_return_instance_is_same_class(self, instance):
+        """Test that the return instance is from the same class"""
+        scaled_instance = instance.scale(factor=2)
+        assert scaled_instance.__class__ is instance.__class__
+
+    def test_scale_factor_parameters(self, instance):
+        """Test that scaling is actually working as expected"""
+        larger_scaled_instance = instance.scale(factor=2)
+        smaller_scaled_instance = instance.scale(factor=.5)
+
+        assert larger_scaled_instance.R == instance.R*2
+        assert larger_scaled_instance.r == instance.r*2
+        assert larger_scaled_instance.d == instance.d*2
+        assert (larger_scaled_instance.thetas == instance.thetas).all()
+
+        assert smaller_scaled_instance.R == instance.R*.5
+        assert smaller_scaled_instance.r == instance.r*.5
+        assert smaller_scaled_instance.d == instance.d*.5
+        assert (smaller_scaled_instance.thetas == instance.thetas).all()
+
     def test_create_range_theta_inputs(self, thetas):
         R = 5
         r = 3


### PR DESCRIPTION
## Description
Add feature that allows for scaling the shape with a method call. `scale` method will not modify the instance in place but instead return a new instance with the scaled parameters. Also in this case the "scaling" is based on scaling the input parameters and not the area within the circles i.e. it isn't scaling the area of the circles it is hard-scaling whatever the input parameters are. Eventually we may want to add an argument to `scale` that allows for different methods of scaling but this naive approach will work for now

Fixes #89 

## Checklist

* [x] I followed the guidelines in our Contributing document
* [x] I added an explanation of my changes