### PR TITLE
Fix cycloid animate method

### DIFF
--- a/docs/_autosummary/spyrograph.epitrochoid.rst
+++ b/docs/_autosummary/spyrograph.epitrochoid.rst
@@ -1,7 +1,7 @@
-spyrograph.epitrochoid
+﻿spyrograph.epitrochoid
 ======================
 
-.. automodule:: spyrograph.epitrochoid.epitrochoid
+.. automodule:: spyrograph.epitrochoid
 
    
    

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding='UTF-8') as fh:
 
 setuptools.setup(
     name="spyrograph",
-    version="0.19.0",
+    version="0.19.1",
     author="Chris Greening",
     author_email="chris@christophergreening.com",
     description="Library for drawing spirographs in Python",

--- a/spyrograph/_cycloid.py
+++ b/spyrograph/_cycloid.py
@@ -5,6 +5,7 @@ shape's methods i.e. tracing, calculating, etc.
 from numbers import Number
 from typing import List, Tuple, Union
 import collections
+import time
 
 from spyrograph._trochoid import _Trochoid
 
@@ -48,6 +49,91 @@ class _Cycloid(_Trochoid):
         origin : Tuple[Number, Number] = (0, 0)
             Custom origin to center the shapes at. Default is (0,0)
         """
+
+    @classmethod
+    def animate(
+            cls, R: Union[Number, List[Number]], r: Union[Number, List[Number]],
+            thetas: List[Number] = None,
+            theta_start: Number = None, theta_stop: Number = None,
+            theta_step: Number = None, origin: Tuple[Number, Number] = (0, 0),
+            screen_size: Tuple[Number, Number] = (1000, 1000),
+            screen_color: str = "white", exit_on_click: bool = False,
+            color: str = "black", width: Number = 1,
+            frame_pause: Number = 0.1, screen: "turtle.Screen" = None
+        ) -> List["_Trochoid"]:
+        """
+        Animate a sequence of _Trochoid shapes with varying input parameters,
+        drawn one after the other.
+
+        Parameters
+        ----------
+        R : Union[Number, List[Number]]
+            Radius of the fixed circle.
+        r : Union[Number, List[Number]]
+            Radius of the rolling circle.
+        thetas : List[Number], optional
+            Input list of values for theta for inputting into parametric equations.
+            This argument cannot be set at the same time as theta_start,
+            theta_stop, theta_step.
+        theta_start : Number, optional
+            Starting theta value for creating a list of thetas (similar syntax
+            to built-in range or np.arange). This argument cannot be set at the
+            same time as thetas argument.
+        theta_stop : Number, optional
+            Stop theta value for creating a list of thetas, stop value is not
+            included in the final array (similar syntax to built-in range or
+            np.arange). This argument cannot be set at the same time as thetas
+            argument.
+        theta_step : Number, optional
+            Incremental step value for stepping from start to stop
+            (similar syntax to built-in range or np.arange). This argument
+            cannot be set at the same time as thetas argument.
+        origin : Tuple[Number, Number], optional, default (0, 0)
+            Custom origin to center the shapes at. Default is (0,0).
+        screen_size : Tuple[Number, Number], optional, default (1000, 1000)
+            Length and width of the output screen.
+        screen_color : str, optional, default "white"
+            Color of the background screen.
+        exit_on_click : bool, optional, default False
+            Pause the final animation until the user clicks to exit the window.
+        color : str, optional, default "black"
+            Color of the primary tracing.
+        width : Number, optional, default 1
+            Width of the turtle tracing.
+        frame_pause : Number, optional, default 0.1
+            Time in seconds to pause between each shape in the animation.
+        screen : turtle.Screen, optional
+            Existing turtle screen.
+
+        Returns
+        -------
+        shapes : List[_Trochoid]
+            A list of instantiated _Trochoid shapes with varying input parameters.
+
+        Examples
+        --------
+        >>> from spyrograph import Hypotrochoid
+        >>> import numpy as np
+        >>> thetas = np.linspace(0, 2 * np.pi, num=1000)
+        >>> shapes = Hypotrochoid.animate(R=10, r=[4, 5, 6], d=8, thetas=thetas)
+        """
+        shapes_arr = cls.create_range(
+            R, r, thetas, theta_start,
+            theta_stop, theta_step, origin
+        )
+        for shape in shapes_arr:
+            if screen is not None:
+                screen.clear()
+                screen.setup(*screen_size)
+                screen.bgcolor(screen_color)
+            screen = shape.trace(
+                screen = screen, screen_size = screen_size,
+                screen_color = screen_color,
+                color = color, width=width
+            )
+            time.sleep(frame_pause)
+        if exit_on_click:
+            turtle.exitonclick()
 
     @classmethod
     def create_range(


### PR DESCRIPTION
## Description
Fixed `animate` method for cycloid shapes by removing the `d` parameter pass

## Checklist

* [x] I followed the guidelines in our Contributing document
* [x] I added an explanation of my changes