### PR TITLE
Fix scale origin value

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding='UTF-8') as fh:
 
 setuptools.setup(
     name="spyrograph",
-    version="0.20.0",
+    version="0.20.1",
     author="Chris Greening",
     author_email="chris@christophergreening.com",
     description="Library for drawing spirographs in Python",

--- a/spyrograph/_trochoid.py
+++ b/spyrograph/_trochoid.py
@@ -148,13 +148,15 @@ class _Trochoid(ABC):
                 R=self.R*factor,
                 r=self.r*factor,
                 d=self.d*factor,
-                thetas=self.thetas
+                thetas=self.thetas,
+                origin=self.origin
             )
         except TypeError:
             scaled_shape = self.__class__(
                 R=self.R*factor,
                 r=self.r*factor,
-                thetas=self.thetas
+                thetas=self.thetas,
+                origin=self.origin
             )
         return scaled_shape
 


### PR DESCRIPTION
## Description
The `scale` method didn't preserve the `origin` attribute when instantiating new shape

## Checklist

* [x] I followed the guidelines in our Contributing document
* [x] I added an explanation of my changes