### PR TITLE
Run Pylint against _Cycloid

### DIFF
--- a/spyrograph/_cycloid.py
+++ b/spyrograph/_cycloid.py
@@ -4,8 +4,8 @@ shape's methods i.e. tracing, calculating, etc.
 
 from numbers import Number
 from typing import List, Tuple, Union
-import collections
 import time
+import turtle
 
 from spyrograph._trochoid import _Trochoid
 from spyrograph._misc import _get_products_of_inputs, _validate_only_one_iterable
@@ -18,6 +18,7 @@ class _Cycloid(_Trochoid):
             theta_step: Number = None, origin: Tuple[Number, Number] = (0, 0)
         ) -> None:
         super().__init__(R, r, r, thetas, theta_start, theta_stop, theta_step, origin)
+        # pylint: disable=pointless-string-statement
         """Instantiate a cycloid curve from given input parameters. A
         hypocycloid is a curve drawn by tracing a point from a circle as it
         rolls around the inside of a fixed circle where the distance
@@ -52,6 +53,7 @@ class _Cycloid(_Trochoid):
         """
 
     @classmethod
+    # pylint: disable=arguments-differ, too-many-locals
     def animate(
             cls, R: Union[Number, List[Number]], r: Union[Number, List[Number]],
             thetas: List[Number] = None,
@@ -134,9 +136,10 @@ class _Cycloid(_Trochoid):
             )
             time.sleep(frame_pause)
         if exit_on_click:
-            turtle.exitonclick()
+            turtle.Screen().exitonclick()
 
     @classmethod
+    # pylint: disable=arguments-differ
     def create_range(
             cls, R: Union[Number, List[Number]], r: Union[Number, List[Number]],
             thetas: List[Number] = None, theta_start: Number = None,


### PR DESCRIPTION
I ran Pylint against _Cycloid. Here's a summary of the issues I ran into and my solutions:

__cycloid.py:21:8: W0105: String statement has no effect (pointless-string-statement)_
Disabled. Pylint sees this string as pointless, because of the string before the import.

__cycloid.py:55:4: W0221: Number of parameters was 16 in '_Trochoid.animate' and is now 15 in overriding '_Cycloid.animate' method (arguments-differ)_
Disabled. No need for argument 'distance'.

__cycloid.py:55:4: R0914: Too many local variables (17/15) (too-many-locals)_
Disabled.

__cycloid.py:137:12: E0602: Undefined variable 'turtle' (undefined-variable)_
Added 'import turtle' at the beginning of the document.

__cycloid.py:140:4: W0221: Number of parameters was 9 in '_Trochoid.create_range' and is now 8 in overriding '_Cycloid.create_range' method (arguments-differ_)
Disabled. No need for argument 'distance'.

__cycloid.py:7:0: W0611: Unused import collections (unused-import)_
Removed 'import collections'.

After disabling and changing code, I performed a second run:

__cycloid.py:139:12: E1101: Module 'turtle' has no 'exitonclick' member (no-member)_
Changed turtle.exitonclick() to turtle.Screen().exitonclick()


Fixes # (issue)
#114 

## Checklist

* [x] I followed the guidelines in our Contributing document
* [x] I added an explanation of my changes

