### PR TITLE
Fix custom origin rotation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding='UTF-8') as fh:
 
 setuptools.setup(
     name="spyrograph",
-    version="0.28.0",
+    version="0.28.1",
     author="Chris Greening",
     author_email="chris@christophergreening.com",
     description="Library for drawing spirographs in Python",

--- a/spyrograph/core/_trochoid.py
+++ b/spyrograph/core/_trochoid.py
@@ -639,9 +639,9 @@ class _Trochoid(ABC):
         """Calculate the parametrized path"""
         self.x = np.array([self._calculate_x(theta) for theta in self.thetas])
         self.y = np.array([self._calculate_y(theta) for theta in self.thetas])
+        self.x, self.y = _apply_rotation(self.x, self.y, self.orientation)
         self.x += self.origin[0]
         self.y += self.origin[1]
-        self.x, self.y = _apply_rotation(self.x, self.y, self.orientation)
         self.min_x = min(self.x)
         self.max_x = max(self.x)
         self.min_y = min(self.y)


### PR DESCRIPTION
## Description
The `rotate` method has an error when a custom origin is set. The rotation matrix is rotating the entire shape itself around the custom origin which is translating the shape up or down but we want to keep it inplace and just rotated

## Checklist

* [x] I followed the guidelines in our Contributing document
* [x] I added an explanation of my changes